### PR TITLE
Display user email instead of _id in metadata

### DIFF
--- a/assets/scripts/resource/ui.js
+++ b/assets/scripts/resource/ui.js
@@ -12,6 +12,7 @@ const uploadFileSuccess = (responseData) => {
 
   const showLastestUpload = showLastestUploadTemplate({ image: responseData.image })
   $('#content').prepend(showLastestUpload)
+  $('#owner-' + responseData.image._id).text('Owner username: ' + store.user.email)
 
   $('form').trigger('reset')
   $('.user-messages').text('Uploaded Successfully!')

--- a/assets/scripts/templates/all-images.handlebars
+++ b/assets/scripts/templates/all-images.handlebars
@@ -14,7 +14,7 @@
         <h6 id="tag-{{image._id}}">Tag: {{image.tag}}</h6>
         <h6 id="created-{{image._id}}">Created: {{image.createdAt}}</h6>
         <h6 id="modified-{{image._id}}">Modified: {{image.updatedAt}}</h6>
-        <h6 id="owner-{{image._id}}">Owner ID: {{image.owner}}</h6>
+        <h6 id="owner-{{image._id}}">Owner username: {{image.owner.email}}</h6>
         <!-- button divs -->
         <div>
           <!-- Download button -->
@@ -45,7 +45,7 @@
         <h6 id="tag-{{image._id}}">Tag: {{image.tag}}</h6>
         <h6 id="created-{{image._id}}">Created: {{image.createdAt}}</h6>
         <h6 id="modified-{{image._id}}">Modified: {{image.updatedAt}}</h6>
-        <h6 id="owner-{{image._id}}">Owner ID: {{image.owner}}</h6>
+        <h6 id="owner-{{image._id}}">Owner username: {{image.owner.email}}</h6>
 
         <!-- Download button -->
         <a href="{{image.url}}" target="_blank">

--- a/assets/scripts/templates/latest-image.handlebars
+++ b/assets/scripts/templates/latest-image.handlebars
@@ -13,7 +13,7 @@
       <h6 id="tag-{{image._id}}">Tag: {{image.tag}}</h6>
       <h6 id="created-{{image._id}}">Created: {{image.createdAt}}</h6>
       <h6 id="modified-{{image._id}}">Modified: {{image.updatedAt}}</h6>
-      <h6 id="owner-{{image._id}}">Owner ID: {{image.owner}}</h6>
+      <h6 id="owner-{{image._id}}">Owner username: {{image.owner.email}}</h6>
       <!-- button divs -->
       <div>
         <!-- Download button -->
@@ -44,7 +44,7 @@
       <h6 id="tag-{{image._id}}">Tag: {{image.tag}}</h6>
       <h6 id="created-{{image._id}}">Created: {{image.createdAt}}</h6>
       <h6 id="modified-{{image._id}}">Modified: {{image.updatedAt}}</h6>
-      <h6 id="owner-{{image._id}}">Owner ID: {{image.owner}}</h6>
+      <h6 id="owner-{{image._id}}">Owner username: {{image.owner.email}}</h6>
 
       <!-- Download button -->
       <a href="{{image.url}}" target="_blank">


### PR DESCRIPTION
+ using the newly modified API routes, display user login email instead of the incomprehensible `_id` property
+ requires the backend API to have merged the new route changes utilizing `.populate()`