### PR TITLE
Updated Google Maps API version to remove warning

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -11,6 +11,7 @@ $(() => {
   authEvents.addHandlers()
   resourceEvents.addHandlers()
   GoogleMapsLoader.KEY = 'AIzaSyAF7N8MH7vYBoQw0nt6Ed_pLcmuapkp0AU'
+  GoogleMapsLoader.VERSION = '3.36'
   GoogleMapsLoader.load(function (google) {
     store.map = new google.maps.Map(document.getElementById('map'), {
       center: {


### PR DESCRIPTION
This should stop the yellow warning in the console.